### PR TITLE
Fix trading engine initialization and restore position entries

### DIFF
--- a/pro_bot/app/main_multitimeframe.py
+++ b/pro_bot/app/main_multitimeframe.py
@@ -79,7 +79,7 @@ class MultitimeframeTradingBot:
         
         # 2. Inicializar trading engine
         self.trading_engine = TradingEngine(self.client)
-        await self.trading_engine.initialize()
+        await self.trading_engine.initialize(symbols=self.symbols)
         log.info("✅ Trading engine initialized")
         
         # 3. Inicializar ML inference engine

--- a/pro_bot/core/execution.py
+++ b/pro_bot/core/execution.py
@@ -344,7 +344,7 @@ def _can_open_new_position(symbol: str) -> bool:
 
 # --- entrada principal ---
 def enter_position(direction: str, use_limit: bool = True, limit_offset_bps: int = 3,
-                   tp_rr: float = 1.5, sl_rr: float = 1.0, symbol: Optional[str] = None) -> dict:
+                   tp_rr: float = 1.5, sl_rr: float = 1.0, symbol: Optional[str] = None) -> Dict[str, object]:
     """Abre una nueva posición y devuelve detalles de la orden."""
     sym = symbol or settings.symbol
     result: Dict[str, object] = {

--- a/pro_bot/core/execution.py
+++ b/pro_bot/core/execution.py
@@ -462,7 +462,7 @@ def enter_position(direction: str, use_limit: bool = True, limit_offset_bps: int
 
 
 # Funciones adicionales para SLTPManager
-def enter_basic(symbol: str, direction: str):
+def enter_basic(symbol: str, direction: str) -> dict:
     """Función básica de entrada de posición para SLTPManager (solo MARKET)"""
     return enter_position(direction, use_limit=False, symbol=symbol)
 

--- a/pro_bot/core/execution.py
+++ b/pro_bot/core/execution.py
@@ -1,6 +1,9 @@
+import asyncio
 import logging
+import threading
+import time
 from decimal import Decimal
-from typing import Optional
+from typing import Dict, List, Optional
 from ..config import settings
 from .client import get_client
 from .exchange import get_filters
@@ -23,6 +26,11 @@ class PositionInfo:
     leverage: int
     liquidationPrice: float
     side: str
+
+_cache_lock = threading.Lock()
+_open_positions_cache: Dict[str, "PositionInfo"] = {}
+_pending_limit_orders_cache: set[str] = set()
+_last_cache_refresh: float = 0.0
 
 def cancel_pending_limit_orders():
     """Cancela todas las órdenes LIMIT pendientes (de entrada)"""
@@ -51,21 +59,25 @@ def cancel_pending_limit_orders():
     except Exception as e:
         log.error(f"Error getting open orders: {e}")
 
-def set_all_symbols_to_crossed_margin():
+def set_all_symbols_to_crossed_margin(extra_symbols: Optional[List[str]] = None):
     """Configura todos los símbolos activos para usar margen cruzado"""
     client = get_client()
-    
+
     # Obtener símbolos con posiciones abiertas
     active_symbols = get_all_open_positions()
-    
+
     # Lista de símbolos comunes para configurar
-    common_symbols = ['BTCUSDT', 'ETHUSDT', 'ADAUSDT', 'LTCUSDT', 'XRPUSDT', 
+    common_symbols = ['BTCUSDT', 'ETHUSDT', 'ADAUSDT', 'LTCUSDT', 'XRPUSDT',
                      'ONTUSDT', '1000PEPEUSDT', 'WIFUSDT', 'SUIUSDT', 'HYPEUSDT',
                      'ENAUSDT', 'LINKUSDT', 'AVAXUSDT', 'PROMPTUSDT', 'FARTCOINUSDT',
                      'BIOUSDT', 'BNBUSDT']
-    
-    all_symbols = list(set(active_symbols + common_symbols))
-    
+
+    merged = set(active_symbols + common_symbols)
+    if extra_symbols:
+        merged.update(extra_symbols)
+
+    all_symbols = list(merged)
+
     log.info(f"🔧 Configurando {len(all_symbols)} símbolos para margen CROSSED...")
     
     success_count = 0
@@ -196,15 +208,19 @@ def get_position_details(symbol: str):
 def get_all_open_positions():
     """Obtener todas las posiciones abiertas desde Binance API"""
     try:
+        with _cache_lock:
+            if _open_positions_cache and (time.time() - _last_cache_refresh) < 60:
+                return sorted(_open_positions_cache.keys())
+
         infos = get_client().client.futures_position_information()
         open_symbols = []
-        
+
         for p in infos:
             sym = p.get("symbol")
             amt = Decimal(p.get("positionAmt", "0"))
             if amt != 0:
                 open_symbols.append(sym)
-        
+
         return sorted(open_symbols)
     except Exception as e:
         log.warning(f"get_all_open_positions error: {e}")
@@ -227,6 +243,50 @@ def get_pending_limit_orders():
         log.warning(f"get_pending_limit_orders error: {e}")
         return []
 
+def _refresh_caches_once(open_positions: Optional[List[PositionInfo]] = None,
+                         pending_limits: Optional[List[str]] = None) -> None:
+    """Actualizar caches internos desde la API"""
+    global _open_positions_cache, _pending_limit_orders_cache, _last_cache_refresh
+
+    positions = open_positions if open_positions is not None else get_all_open_positions_info()
+    pending = pending_limits if pending_limits is not None else get_pending_limit_orders()
+
+    with _cache_lock:
+        _open_positions_cache = {p.symbol: p for p in positions}
+        _pending_limit_orders_cache = set(pending)
+        _last_cache_refresh = time.time()
+
+    log.debug(
+        "Cache actualizado: %d posiciones abiertas, %d órdenes LIMIT pendientes",
+        len(_open_positions_cache),
+        len(_pending_limit_orders_cache),
+    )
+
+def refresh_open_positions_cache(poll_interval: int = 30):
+    """Actualiza el cache de posiciones. En hilos daemon corre en bucle."""
+
+    def _update():
+        try:
+            _refresh_caches_once()
+        except Exception as e:
+            log.warning(f"refresh_open_positions_cache error: {e}")
+
+    if threading.current_thread().daemon:
+        while True:
+            _update()
+            time.sleep(poll_interval)
+    else:
+        _update()
+
+def get_cached_open_positions() -> List[str]:
+    """Devuelve símbolos del cache actual."""
+    with _cache_lock:
+        return sorted(_open_positions_cache.keys())
+
+def get_cached_pending_orders() -> List[str]:
+    with _cache_lock:
+        return sorted(_pending_limit_orders_cache)
+
 def get_active_trading_symbols():
     """Obtener símbolos con posiciones abiertas (ya no incluye órdenes LIMIT)"""
     open_positions = get_all_open_positions()
@@ -244,6 +304,10 @@ def active_trading_count() -> int:
 def has_pending_limit_order(symbol: str) -> bool:
     """Verificar si hay una orden LIMIT pendiente para un símbolo"""
     try:
+        with _cache_lock:
+            if _pending_limit_orders_cache and (time.time() - _last_cache_refresh) < 60:
+                return symbol in _pending_limit_orders_cache
+
         orders = get_client().client.futures_get_open_orders(symbol=symbol)
         for order in orders:
             if order.get("type") == "LIMIT" and order.get("status") == "NEW":
@@ -280,37 +344,66 @@ def _can_open_new_position(symbol: str) -> bool:
 
 # --- entrada principal ---
 def enter_position(direction: str, use_limit: bool = True, limit_offset_bps: int = 3,
-                   tp_rr: float = 1.5, sl_rr: float = 1.0, symbol: Optional[str] = None):
-    """
-    Abre una nueva posición. No modifica posiciones existentes.
-    """
+                   tp_rr: float = 1.5, sl_rr: float = 1.0, symbol: Optional[str] = None) -> dict:
+    """Abre una nueva posición y devuelve detalles de la orden."""
     sym = symbol or settings.symbol
+    result: Dict[str, object] = {
+        "success": False,
+        "symbol": sym,
+        "direction": direction,
+    }
 
-    # --- Límite de posiciones activas (solo abiertas) ---
-    MAX_ACTIVE_POSITIONS = 5
-    current_active = len(get_all_open_positions_info())  # Solo posiciones abiertas
-    if current_active >= MAX_ACTIVE_POSITIONS:
-        log.info(f"Límite de {MAX_ACTIVE_POSITIONS} posiciones activas alcanzado. No se abre {sym}. Activas: {current_active}")
-        return
+    try:
+        max_positions = int(getattr(settings, "max_open_positions", 5))
+    except Exception:
+        max_positions = 5
 
-    # --- Evitar modificar una posición existente ---
-    # La lógica actual no modifica la cantidad de una posición ya abierta.
-    # Simplemente abre una nueva si no existe para este símbolo.
+    current_positions = get_all_open_positions_info()
+    current_active = len(current_positions)
+    if current_active >= max_positions:
+        msg = f"Límite de {max_positions} posiciones activas alcanzado. No se abre {sym}. Activas: {current_active}"
+        log.info(msg)
+        result["error"] = msg
+        return result
+
     if has_open_position(sym):
-        log.info(f"[{sym}] ya hay posición abierta; se omite nueva entrada.")
-        return
+        msg = f"[{sym}] ya hay posición abierta; se omite nueva entrada."
+        log.info(msg)
+        result["error"] = msg
+        return result
 
-    px = Decimal(str(last_price(sym)))
+    if has_pending_limit_order(sym):
+        msg = f"[{sym}] orden LIMIT pendiente detectada; no se abre nueva posición"
+        log.info(msg)
+        result["error"] = msg
+        return result
+
+    try:
+        px = Decimal(str(last_price(sym)))
+    except Exception as exc:
+        msg = f"[{sym}] error obteniendo precio: {exc}"
+        log.error(msg)
+        result["error"] = msg
+        return result
+
     f = get_filters(sym)
 
-    # qty usando nuevo cálculo: MIN_NOTIONAL / ENTRY_PRICE
-    qty, lev = decide_qty_for_margin(sym, float(px))
+    try:
+        qty, lev = decide_qty_for_margin(sym, float(px))
+    except Exception as exc:
+        msg = f"[{sym}] error calculando cantidad: {exc}"
+        log.error(msg)
+        result["error"] = msg
+        return result
+
     if qty <= 0:
-        raise ValueError(f"[{sym}] Qty inválida para MIN_NOTIONAL: {f.min_notional}")
+        msg = f"[{sym}] Qty inválida para MIN_NOTIONAL: {f.min_notional}"
+        log.error(msg)
+        result["error"] = msg
+        return result
 
     qty_str = f.fmt_qty(qty)
 
-    # precios y orden market
     if direction == "LONG":
         side_open = SIDE["BUY"]
         tp = px * (Decimal("1") + Decimal("0.03") * Decimal(str(tp_rr)))
@@ -320,15 +413,52 @@ def enter_position(direction: str, use_limit: bool = True, limit_offset_bps: int
         tp = px * (Decimal("1") - Decimal("0.03") * Decimal(str(tp_rr)))
         sl = px * (Decimal("1") + Decimal("0.02") * Decimal(str(sl_rr)))
     else:
-        log.info(f"[{sym}] NEUTRAL; no se abre posición.")
-        return
+        msg = f"[{sym}] señal NEUTRAL; no se abre posición"
+        log.info(msg)
+        result["error"] = msg
+        return result
 
-    # enviar orden MARKET
-    ord_resp = market_order(side_open, sym, qty_str)
-    log.info(f"[{sym}] MARKET order placed: {ord_resp.get('orderId','?')}")
+    try:
+        ord_resp = market_order(side_open, sym, qty_str)
+    except Exception as exc:
+        msg = f"[{sym}] error creando orden MARKET: {exc}"
+        log.error(msg)
+        result["error"] = msg
+        return result
 
-    # TP/SL
+    order_id = ord_resp.get("orderId", "?")
+    log.info(f"[{sym}] MARKET order placed: {order_id}")
+
+    result.update({
+        "order": ord_resp,
+        "side": side_open,
+        "qty": float(qty),
+        "qty_str": qty_str,
+        "leverage": lev,
+        "tp_price": float(tp),
+        "sl_price": float(sl),
+    })
+
     place_tp_sl(sym, side_open, tp, sl)
+
+    position_details = get_position_details(sym)
+    if position_details:
+        entry_price = float(position_details["entryPrice"])
+        filled_qty = abs(float(position_details["positionAmt"]))
+    else:
+        entry_price = float(px)
+        filled_qty = float(qty)
+
+    result.update({
+        "entry_price": entry_price,
+        "filled_qty": filled_qty,
+        "success": True,
+    })
+
+    # Refrescar caches tras la operación
+    _refresh_caches_once()
+
+    return result
 
 
 # Funciones adicionales para SLTPManager
@@ -387,3 +517,99 @@ def take_profit_market(symbol: str, side: str, stop_price: float, qty: Optional[
     except Exception as e:
         log.error(f"Error creating take profit market order: {e}")
         return None
+
+
+class TradingEngine:
+    """Motor de ejecución asincrónico utilizado por el bot multitimeframe."""
+
+    def __init__(self, client, cfg_path: str = "configs/ml.yaml"):
+        self.client = client
+        self.cfg_path = cfg_path
+        self.symbols: List[str] = []
+        self.initialized = False
+        self._locks_guard = asyncio.Lock()
+        self._symbol_locks: Dict[str, asyncio.Lock] = {}
+
+    async def initialize(self, symbols: Optional[List[str]] = None) -> None:
+        """Inicializa el motor configurando margen y refrescando caches."""
+        if symbols is not None:
+            self.symbols = list(symbols)
+
+        await asyncio.to_thread(refresh_open_positions_cache)
+        extra = self.symbols if self.symbols else None
+        await asyncio.to_thread(set_all_symbols_to_crossed_margin, extra)
+        await asyncio.to_thread(cancel_pending_limit_orders)
+        self.initialized = True
+        log.info("✅ TradingEngine ready (margen CROSSED verificado)")
+
+    async def cleanup(self) -> None:
+        """Limpieza al detener el motor."""
+        await asyncio.to_thread(cancel_pending_limit_orders)
+        await asyncio.to_thread(refresh_open_positions_cache)
+        self._symbol_locks.clear()
+        self.initialized = False
+
+    async def _get_symbol_lock(self, symbol: str) -> asyncio.Lock:
+        async with self._locks_guard:
+            lock = self._symbol_locks.get(symbol)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._symbol_locks[symbol] = lock
+            return lock
+
+    async def get_position(self, symbol: str) -> Optional[dict]:
+        details = await asyncio.to_thread(get_position_details, symbol)
+        if not details:
+            return None
+
+        normalized = dict(details)
+        for key in ("positionAmt", "entryPrice", "unrealizedPnl", "percentage"):
+            if key in normalized and normalized[key] is not None:
+                try:
+                    normalized[key] = float(normalized[key])
+                except Exception:
+                    pass
+        return normalized
+
+    async def _enter(self, symbol: str, direction: str) -> dict:
+        lock = await self._get_symbol_lock(symbol)
+        async with lock:
+            try:
+                result = await asyncio.to_thread(
+                    enter_position,
+                    direction,
+                    False,
+                    3,
+                    1.5,
+                    1.0,
+                    symbol,
+                )
+            except Exception as exc:
+                log.error(f"[{symbol}] error ejecutando entrada {direction}: {exc}")
+                return {
+                    "success": False,
+                    "symbol": symbol,
+                    "direction": direction,
+                    "error": str(exc),
+                }
+
+            if not result:
+                return {
+                    "success": False,
+                    "symbol": symbol,
+                    "direction": direction,
+                    "error": "enter_position returned no data",
+                }
+
+            if not result.get("success"):
+                log.warning(f"[{symbol}] no se pudo abrir posición {direction}: {result.get('error')}")
+            else:
+                log.info(f"[{symbol}] posición {direction} abierta correctamente")
+
+            return result
+
+    async def enter_long_position(self, symbol: str) -> dict:
+        return await self._enter(symbol, "LONG")
+
+    async def enter_short_position(self, symbol: str) -> dict:
+        return await self._enter(symbol, "SHORT")

--- a/pro_bot/core/sl_tp_manager.py
+++ b/pro_bot/core/sl_tp_manager.py
@@ -159,7 +159,7 @@ class SLTPManager:
 
         basic = enter_basic(self.symbol, direction)
         if not basic or not basic.get("success"):
-            log.warning(f"[{self.symbol}] ❌ No se pudo abrir posición básica: {basic.get('error') if isinstance(basic, dict) else basic}")
+            log.warning(f"[{self.symbol}] ❌ No se pudo abrir posición básica: {basic.get('error', 'Unknown error')}")
             return
 
         entry_price = float(basic.get("entry_price", last_price(self.symbol)))

--- a/pro_bot/core/sl_tp_manager.py
+++ b/pro_bot/core/sl_tp_manager.py
@@ -158,12 +158,17 @@ class SLTPManager:
         self._validate_tp_setup()
 
         basic = enter_basic(self.symbol, direction)
-        if basic is None:
+        if not basic or not basic.get("success"):
+            log.warning(f"[{self.symbol}] ❌ No se pudo abrir posición básica: {basic.get('error') if isinstance(basic, dict) else basic}")
             return
 
-        entry_price = basic["entry_price"]
-        qty = basic["qty"]
-        side_open = basic["side"]   # BUY for long, SELL for short
+        entry_price = float(basic.get("entry_price", last_price(self.symbol)))
+        qty = float(basic.get("filled_qty", basic.get("qty", 0.0)))
+        side_open = basic.get("side", "BUY" if direction == "LONG" else "SELL")   # BUY for long, SELL for short
+
+        if qty <= 0:
+            log.error(f"[{self.symbol}] ❌ Cantidad inválida devuelta por enter_basic: {qty}")
+            return
 
         if direction == "LONG":
             sl_price = entry_price - self.stop_loss_atr_mult * atr

--- a/pro_bot/core/symbols.py
+++ b/pro_bot/core/symbols.py
@@ -76,3 +76,30 @@ def forced_symbols_from_env():
         if x not in seen:
             out.append(x); seen.add(x)
     return out
+
+
+DEFAULT_TRADING_SYMBOLS = [
+    "BTCUSDT", "ETHUSDT", "BNBUSDT", "SOLUSDT", "XRPUSDT",
+    "ADAUSDT", "DOGEUSDT", "LTCUSDT", "TRXUSDT", "LINKUSDT",
+    "AVAXUSDT", "MATICUSDT", "DOTUSDT", "OPUSDT", "ARBUSDT",
+    "SUIUSDT", "1000PEPEUSDT", "APTUSDT", "ATOMUSDT",
+]
+
+
+def get_trading_symbols(client=None, limit: int = 19) -> List[str]:
+    """Obtiene la lista de símbolos a operar respetando configuraciones y fallback."""
+    forced = forced_symbols_from_env()
+    if forced:
+        log.info(f"Usando {len(forced)} símbolos definidos en SYMBOLS")
+        return forced[:limit]
+
+    try:
+        top_symbols = top_usdtm_symbols_by_quote_volume(limit)
+        if top_symbols:
+            log.info(f"Seleccionados {len(top_symbols)} símbolos por volumen 24h")
+            return top_symbols
+    except Exception as exc:
+        log.warning(f"No se pudo obtener símbolos por volumen: {exc}")
+
+    log.warning("Usando lista de símbolos por defecto")
+    return DEFAULT_TRADING_SYMBOLS[:limit]


### PR DESCRIPTION
## Summary
- add execution cache utilities and a TradingEngine class that refreshes margin/caches and wraps position entries
- return structured data from `enter_position`, update SL/TP manager handling, and refresh caches after orders
- expose `get_trading_symbols` for multitimeframe setups and wire symbol lists into the trading engine

## Testing
- python -m compileall pro_bot

------
https://chatgpt.com/codex/tasks/task_e_68c94ab6ec6c8322b1c0790c4b101013